### PR TITLE
Parsha fix for kHebrewYearTypeD

### DIFF
--- a/KosherCocoa/Library/Core/Calendar/Parasha/KCParashatHashavuaCalculator.m
+++ b/KosherCocoa/Library/Core/Calendar/Parasha/KCParashatHashavuaCalculator.m
@@ -280,7 +280,8 @@
                      @(KCParashaBehaalotecha),
                      @(KCParashaShelach),
                      @(KCParashaKorach),
-                     @(KCParashaChukatAndBalak),
+                     @(KCParashaChukat),
+                     @(KCParashaBalak),
                      @(KCParashaPinchas),
                      @(KCParashaMatotAndMasei),
                      


### PR DESCRIPTION
Not sure if you already made this fix somewhere, but it's not at the head revision.