### PR TITLE
bug fix to not include timezone additions

### DIFF
--- a/KosherCocoa/Library/Core/Solar/KCAstronomicalCalendar.m
+++ b/KosherCocoa/Library/Core/Solar/KCAstronomicalCalendar.m
@@ -313,11 +313,11 @@
     
     if (time + offsetFromGMT > 24)
     {
-        returnDate = [self dateBySubtractingDays:1 fromDate:returnDate];
+        returnDate = [NSDate dateWithTimeInterval:-86400 sinceDate:returnDate];
     }
     else if(time + offsetFromGMT < 0)
     {
-        returnDate = [self dateByAddingDays:1 toDate:returnDate];
+        returnDate = [NSDate dateWithTimeInterval:86400 sinceDate:returnDate];
     }
     
     return returnDate;


### PR DESCRIPTION
This PR fixes an issue that happens when the timezone changes the next or previous day. The only problem this fix might present is accuracy, as not every day is 84,000 seconds from what I remember.